### PR TITLE
npmのstartスクリプト修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "postinstall": "npm run build",
-    "start": "vue-cli-service serve --open"
+    "start": "node server.js"
   },
   "dependencies": {
     "axios": "^0.20.0",


### PR DESCRIPTION
startスクリプトが書き換わったいたので本番環境でもエラーになっていた

明示的に変更はしていないのでmdbvueをインストールした時に書き換わったのかもしれない